### PR TITLE
Add R.utils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN conda update conda --yes \
     r-knitr \
     r-maps \
     r-microbenchmark \
+    r-r.utils \
     r-raster \
     r-rastervis \
     r-rgdal \


### PR DESCRIPTION
This PR adds `r-r.utils` to the conda environment setup. This package is needed for error handling in case a knit job is stuck/runs indefinitely, see 

https://github.com/earthlab/eds-lessons-dev/pull/78

and 

https://github.com/earthlab/eds-lessons-dev/issues/75