### PR TITLE
Add cyphr to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN conda update conda --yes \
     pyqt \
     pysal \
     r-codetools \
+    r-cyphr\
     r-dplyr \
     r-ff \
     r-ggmap \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,8 @@ RUN apt-get update \
     && apt install ~/Downloads/ttf-mscorefonts-installer_3.7_all.deb -y \
     && apt-mark hold ttf-mscorefonts-installer
 
-RUN R --silent -e "devtools::install_github('earthlab/qtoolkit', dependencies = FALSE)" 
+RUN ln -s /bin/tar /bin/gtar \ 
+    && R --silent -e "devtools::install_github('earthlab/qtoolkit', dependencies = FALSE)" 
 
 COPY import_check.py import_check.py
 RUN python import_check.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,14 +30,20 @@ RUN conda update conda --yes \
     pyproj \
     pyqt \
     pysal \
+    r-bookdown \
     r-codetools \
-    r-cyphr\
+    r-cyphr \
+    r-curl \
+    r-devtools \
     r-dplyr \
     r-ff \
     r-ggmap \
     r-ggplot2 \
     r-gridextra \
+    r-kableextra \  
     r-knitr \
+    r-lemon \
+    r-magick \
     r-maps \
     r-microbenchmark \
     r-r.utils \
@@ -47,6 +53,7 @@ RUN conda update conda --yes \
     r-rgeos \
     r-rjsonio \
     r-rmarkdown \
+    r-reshape \
     r-rsaga \
     r-rtweet \
     r-sf \
@@ -80,6 +87,8 @@ RUN apt-get update \
     && wget http://ftp.de.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.7_all.deb -P ~/Downloads \
     && apt install ~/Downloads/ttf-mscorefonts-installer_3.7_all.deb -y \
     && apt-mark hold ttf-mscorefonts-installer
+
+RUN R --silent -e "devtools::install_github('earthlab/qtoolkit', dependencies = FALSE)" 
 
 COPY import_check.py import_check.py
 RUN python import_check.py


### PR DESCRIPTION
The R package `cyphr`, which we are using to handle file encryption for the EDS lessons build, is now on conda-forge (thanks @ocefpaf!). This PR adds it to our Dockerfile. 