### PR TITLE
remove freeze installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE=true
 RUN conda update conda --yes \
     && conda config --add channels conda-forge \
     && conda config --set channel_priority strict \
-    && conda install --yes --freeze-installed \
+    && conda install --yes \
     python=3.7 \
     r-base=3.5 \
     autopep8 \


### PR DESCRIPTION
@lwasser this should fix your build. The packages are OK it was the `--freeze-installed` option that prevent some of the pre-existing packages on `miniconda` to be upgraded. 

Note that `--freeze-installed` is usually a good idea but this project install a lot of packages and you probably need more "freedom" to upgrade the dependencies.