### PR TITLE
Add mapdata to conda envt setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN conda update conda --yes \
     r-knitr \
     r-lemon \
     r-magick \
+    r-mapdata \ 
     r-maps \
     r-microbenchmark \
     r-r.utils \


### PR DESCRIPTION
This PR adds the R library `mapdata` to our conda environment setup, which looks to now be needed to rebuild some of the Week 3 R course lessons involving `ggmap` (see https://github.com/earthlab/eds-lessons-dev/pull/104).