### PR TITLE
Add packages for R Course Week 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN apt-get update \
     && apt-mark hold ttf-mscorefonts-installer
 
 RUN ln -s /bin/tar /bin/gtar \ 
-    && R --silent -e "devtools::install_github('earthlab/qtoolkit', dependencies = FALSE)" 
+    && R --silent -e "devtools::install_github('earthlab/qtoolkit', dependencies = FALSE)" \
     && R --silent -e "devtools::install_github('oswaldosantos/ggsn', dependencies = FALSE)" 
 
 COPY import_check.py import_check.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN conda update conda --yes \
     pysal \
     r-bookdown \
     r-codetools \
+    r-cowplot \
     r-cyphr \
     r-curl \
     r-devtools \
@@ -48,6 +49,7 @@ RUN conda update conda --yes \
     r-magick \
     r-mapdata \ 
     r-maps \
+    r-maptools \
     r-microbenchmark \
     r-plotly \
     r-r.utils \


### PR DESCRIPTION
This PR adds the following packages needed to rebuild lessons in R Course Week 4 (see earthlab/eds-lessons-dev#124): 

- `cowplot`
- `maptools`'
- `ggsn` (there is no `conda-forge` feedstock for this one as of now -- I am currently using `devtools::install-github` to install it). 