### PR TITLE
Add ggsn to conda environment setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN conda update conda --yes \
     r-ff \
     r-ggmap \
     r-ggplot2 \
+    r-ggsn \
     r-gridextra \
     r-kableextra \  
     r-knitr \


### PR DESCRIPTION
This PR adds `r-ggsn`, required for one of the R Course Week 4 lessons, to our Dockerfile. 