### PR TITLE
add descartes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,13 @@ RUN conda update conda --yes \
     cenpy \
     climata \
     contextily \
+    descartes \
     earthpy \
     elevation \
     folium \
     geocoder \
     geojson \
-    geopandas >=0.7 \
+    geopandas \
     geopy \
     hydrofunctions \
     mapboxgl \


### PR DESCRIPTION
descartes is a non required (but kind of required) dep of geopandas.
It's no long installed by default so i'm adding it to our envt
given this should install the newest geopandas i'm also removing the version requirement