### PR TITLE
force update papermill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN conda update conda --yes \
     nano \
     nbclean \
     nltk \
-    papermill \
+    papermill>2.0.0 \
     pyproj \
     pyqt \
     pysal \


### PR DESCRIPTION
Papermill fix to fix dead kernel errors

Papermill is currently dying sometimes due to a dead kernel issue addressed below:

https://github.com/nteract/papermill/issues/478#event-3184771797

this updates the envt to use the current fixed version !