### PR TITLE
push to correct dockerhub repo

### DIFF
--- a/.github/workflows/build-push-release.yml
+++ b/.github/workflows/build-push-release.yml
@@ -22,7 +22,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+          images: earthlab/r-python-eds-lessons-env
       
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc


### PR DESCRIPTION
closes #51 
i'm being too lazy today but this should push a tagged version to dockerhub. 
To edit this file you need to

1. update secrets with secrets from your org or repo - this allows you to authenticate with dockerhub
2. update the repo on dockerhub that this should push to